### PR TITLE
Fix code scanning alert no. 1: CSRF protection weakened or disabled

### DIFF
--- a/backend/app/controllers/concerns/devise_concern.rb
+++ b/backend/app/controllers/concerns/devise_concern.rb
@@ -2,7 +2,6 @@ module DeviseConcern
   extend ActiveSupport::Concern
 
   included do
-    skip_before_action :verify_authenticity_token, raise: false
   end
 
   protected

--- a/backend/app/controllers/concerns/devise_concern.rb
+++ b/backend/app/controllers/concerns/devise_concern.rb
@@ -1,9 +1,6 @@
 module DeviseConcern
   extend ActiveSupport::Concern
 
-  included do
-  end
-
   protected
 
   # used by devise


### PR DESCRIPTION
Fixes [https://github.com/bretheskevin/template-rails-next/security/code-scanning/1](https://github.com/bretheskevin/template-rails-next/security/code-scanning/1)

To fix the CSRF vulnerability, we need to re-enable CSRF protection by removing the `skip_before_action :verify_authenticity_token, raise: false` line. This will ensure that all actions in the controller are protected against CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
